### PR TITLE
Added taxonomy tests to e2e-custom

### DIFF
--- a/.github/workflows/e2e-aws-custom.yml
+++ b/.github/workflows/e2e-aws-custom.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          ec2-image-id: ami-01a89eee1adde309c
+          ec2-image-id: ${{ vars.AWS_EC2_AMI }}
           ec2-instance-type: ${{ github.event.inputs.instance_type }}
           subnet-id: subnet-024298cefa3bedd61
           security-group-id: sg-06300447c4a5fbef3

--- a/.github/workflows/e2e-aws-custom.yml
+++ b/.github/workflows/e2e-aws-custom.yml
@@ -134,14 +134,20 @@ jobs:
 
       - name: Install ilab
         run: |
-          export PATH="/home/ec2-user/.local/bin:/usr/local/cuda/bin:$PATH"
+          export CUDA_HOME="/usr/local/cuda"
+          export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64"
+          export PATH="$PATH:$CUDA_HOME/bin"
           python3.11 -m venv --upgrade-deps venv
           . venv/bin/activate
-          sed 's/\[.*\]//' requirements.txt > constraints.txt
+          nvidia-smi
           python3.11 -m pip cache remove llama_cpp_python
-          CMAKE_ARGS="-DLLAMA_CUBLAS=on" python3.11 -m pip install --force-reinstall --no-binary llama_cpp_python -c constraints.txt llama_cpp_python
-          python3.11 -m pip install bitsandbytes
-          python3.11 -m pip install ${{ github.event.inputs.ilab_install_target }}
+
+          CMAKE_ARGS="-DGGML_CUDA=on" python3.11 -m pip install -v .
+
+          # https://github.com/instructlab/instructlab/issues/1821
+          # install with Torch and build dependencies installed
+          python3.11 -m pip install -v packaging wheel setuptools-scm
+          python3.11 -m pip install -v ${{ github.event.inputs.ilab_install_target }}
 
       - name: Check disk before tests
         run: |

--- a/.github/workflows/e2e-nvidia-l4-x1.yml
+++ b/.github/workflows/e2e-nvidia-l4-x1.yml
@@ -139,6 +139,7 @@ jobs:
       - name: Run e2e test
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           . venv/bin/activate
           ./scripts/e2e-ci.sh -m

--- a/.github/workflows/e2e-nvidia-l40s-x4.yml
+++ b/.github/workflows/e2e-nvidia-l40s-x4.yml
@@ -149,6 +149,7 @@ jobs:
       - name: Run e2e test
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           . venv/bin/activate
           ./scripts/e2e-ci.sh -l

--- a/.github/workflows/e2e-nvidia-l40s-x8.yml
+++ b/.github/workflows/e2e-nvidia-l40s-x8.yml
@@ -18,9 +18,11 @@ env:
 jobs:
   start-xlarge-ec2-runner:
     runs-on: ubuntu-latest
+    env:
+      INSTANCE_TYPE: "g6e.48xlarge"
     outputs:
-      label: ${{ steps.start-ec2-runner.outputs.label }}
-      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
+      label: ${{ steps.selected-availability-zone.outputs.label }}
+      ec2-instance-id: ${{ steps.selected-availability-zone.outputs.ec2-instance-id }}
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -39,14 +41,39 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ vars.AWS_REGION }}
 
-      - name: Start EC2 runner
-        id: start-ec2-runner
+      # Attempt to launch the EC2 runner on us-east-2a. If it fails to launch due to insufficient capacity
+      # for this instance, we will continue and try another availability zone within this region.
+      - name: Attempt to start EC2 runner on us-east-2a
+        id: start-ec2-runner-us-east-2a
         uses: machulav/ec2-github-runner@fcfb31a5760dad1314a64a0e172b78ec6fc8a17e # v2.3.6
+        continue-on-error: true
         with:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           ec2-image-id: ${{ vars.AWS_EC2_AMI }}
-          ec2-instance-type: g6e.48xlarge
+          ec2-instance-type: ${{ env.INSTANCE_TYPE }}
+          subnet-id: subnet-02d230cffd9385bd4
+          security-group-id: sg-06300447c4a5fbef3
+          iam-role-name: instructlab-ci-runner
+          aws-resource-tags: >
+            [
+              {"Key": "Name", "Value": "instructlab-ci-github-xlarge-runner"},
+              {"Key": "GitHubRepository", "Value": "${{ github.repository }}"},
+              {"Key": "GitHubRef", "Value": "${{ github.ref }}"},
+              {"Key": "GitHubPR", "Value": "${{ github.event.number }}"}
+            ]
+
+      # Fallback in case of failure
+      - name: Attempt to start EC2 runner on us-east-2b (if us-east-2a failed)
+        if: steps.start-ec2-runner-us-east-2a.outcome == 'failure'
+        id: start-ec2-runner-us-east-2b
+        uses: machulav/ec2-github-runner@fcfb31a5760dad1314a64a0e172b78ec6fc8a17e # v2.3.6
+        continue-on-error: true
+        with:
+          mode: start
+          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          ec2-image-id: ${{ vars.AWS_EC2_AMI }}
+          ec2-instance-type: ${{ env.INSTANCE_TYPE }}
           subnet-id: subnet-024298cefa3bedd61
           security-group-id: sg-06300447c4a5fbef3
           iam-role-name: instructlab-ci-runner
@@ -57,6 +84,44 @@ jobs:
               {"Key": "GitHubRef", "Value": "${{ github.ref }}"},
               {"Key": "GitHubPR", "Value": "${{ github.event.number }}"}
             ]
+
+      # Only try us-east-2c if the previous two availability zones had no availability, but
+      # do not continue if we see a failure here. Assume we've exhausted all options at that
+      # point in time.
+      - name: Attempt to start EC2 runner on us-east-2c (if us-east-2b failed)
+        if: steps.start-ec2-runner-us-east-2b.outcome == 'failure'
+        id: start-ec2-runner-us-east-2c
+        uses: machulav/ec2-github-runner@fcfb31a5760dad1314a64a0e172b78ec6fc8a17e # v2.3.6
+        with:
+          mode: start
+          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          ec2-image-id: ${{ vars.AWS_EC2_AMI }}
+          ec2-instance-type: ${{ env.INSTANCE_TYPE }}
+          subnet-id: subnet-04701a08396b2ed01
+          security-group-id: sg-06300447c4a5fbef3
+          iam-role-name: instructlab-ci-runner
+          aws-resource-tags: >
+            [
+              {"Key": "Name", "Value": "instructlab-ci-github-xlarge-runner"},
+              {"Key": "GitHubRepository", "Value": "${{ github.repository }}"},
+              {"Key": "GitHubRef", "Value": "${{ github.ref }}"},
+              {"Key": "GitHubPR", "Value": "${{ github.event.number }}"}
+            ]
+
+      - name: Determine EC2 availability zone used
+        id: selected-availability-zone
+        run: |
+          # shellcheck disable=SC2086 # False positive error from shellcheck about word splitting/gobbling
+          if [ "${{ steps.start-ec2-runner-us-east-2a.outcome }}" = "success" ]; then
+            echo "label=${{ steps.start-ec2-runner-us-east-2a.outputs.label }}" >> $GITHUB_OUTPUT
+            echo "ec2-instance-id=${{ steps.start-ec2-runner-us-east-2a.outputs.ec2-instance-id }}" >> $GITHUB_OUTPUT
+          elif [ "${{ steps.start-ec2-runner-us-east-2b.outcome }}" = "success" ]; then
+            echo "label=${{ steps.start-ec2-runner-us-east-2b.outputs.label }}" >> $GITHUB_OUTPUT
+            echo "ec2-instance-id=${{ steps.start-ec2-runner-us-east-2b.outputs.ec2-instance-id }}" >> $GITHUB_OUTPUT
+          elif [ "${{ steps.start-ec2-runner-us-east-2c.outcome }}" = "success" ]; then
+            echo "label=${{ steps.start-ec2-runner-us-east-2c.outputs.label }}" >> $GITHUB_OUTPUT
+            echo "ec2-instance-id=${{ steps.start-ec2-runner-us-east-2c.outputs.ec2-instance-id }}" >> $GITHUB_OUTPUT
+          fi
 
   e2e-xlarge-test:
     needs:

--- a/.github/workflows/stale_bot.yml
+++ b/.github/workflows/stale_bot.yml
@@ -47,3 +47,4 @@ jobs:
             This pull request has been automatically closed due to inactivity. Please feel free to reopen if you intend to continue working on it!
           days-before-pr-stale: 60
           days-before-pr-close: 30
+          operations-per-run: 90

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,11 +7,11 @@ datasets>=2.18.0
 gguf>=0.6.0
 GitPython>=3.1.42
 httpx>=0.25.0
-instructlab-eval>=0.4.2
+instructlab-eval>=0.5.1
 instructlab-quantize>=0.1.0
-instructlab-schema>=0.4.0
-instructlab-sdg>=0.6.3
-instructlab-training>=0.6.0
+instructlab-schema>=0.4.2
+instructlab-sdg>=0.7.0
+instructlab-training>=0.7.0
 llama_cpp_python[server]==0.3.2
 mlx>=0.5.1,<0.6.0; sys_platform == 'darwin' and platform_machine == 'arm64'
 numpy>=1.26.4,<2.0.0

--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -1,2 +1,2 @@
 # Extra dependencies for NVIDIA CUDA
-instructlab-training[cuda]>=0.6.0
+instructlab-training[cuda]>=0.7.0

--- a/requirements/hpu.txt
+++ b/requirements/hpu.txt
@@ -10,4 +10,4 @@ habana_gpu_migration>=1.18.0
 #habana-torch-dataloader
 
 # Extra dependencies for Intel Gaudi cards
-instructlab-training[hpu]>=0.6.0
+instructlab-training[hpu]>=0.7.0

--- a/requirements/rocm.txt
+++ b/requirements/rocm.txt
@@ -1,2 +1,2 @@
 # Extra dependencies for AMD ROCm
-instructlab-training[rocm]>=0.6.0
+instructlab-training[rocm]>=0.7.0

--- a/src/instructlab/cli/model/chat.py
+++ b/src/instructlab/cli/model/chat.py
@@ -107,6 +107,7 @@ logger = logging.getLogger(__name__)
     "rag_enabled",
     default=False,
     is_flag=True,
+    help="To enable the RAG pipeline.",
 )
 @click.option(
     "--document-store-uri",

--- a/src/instructlab/cli/model/evaluate.py
+++ b/src/instructlab/cli/model/evaluate.py
@@ -135,6 +135,11 @@ logger = logging.getLogger(__name__)
     is_flag=True,
     help="Print serving engine logs.",
 )
+@click.option(
+    "--skip-server",
+    is_flag=True,
+    help="Skip launching the server and evaluate directly with the HuggingFace model. This option supports mmlu and mmlu_branch benchmarks.",
+)
 @click.pass_context
 @clickext.display_params
 def evaluate(
@@ -160,6 +165,7 @@ def evaluate(
     tls_client_key,  # pylint: disable=unused-argument
     tls_client_passwd,  # pylint: disable=unused-argument
     enable_serving_output,
+    skip_server: bool,
 ) -> None:
     """Evaluates a trained model"""
     try:
@@ -186,6 +192,7 @@ def evaluate(
             tls_client_key,
             tls_client_passwd,
             enable_serving_output,
+            skip_server,
         )
     except Exception as e:
         logger.error(f"An error occurred during evaluation: {str(e)}")

--- a/src/instructlab/common.py
+++ b/src/instructlab/common.py
@@ -7,10 +7,12 @@ CLI_HELPER_SYS_PROMPT = "You are an expert for command line interface and know a
 class SupportedModelArchitectures:
     LLAMA = "llama"
     GRANITE = "granite"
+    GRANITE3_128K = "granite-3.1"
 
 
 # These system prompts are specific to granite models developed by Red Hat and IBM Research
 SYSTEM_PROMPTS = {
     SupportedModelArchitectures.LLAMA: "I am, Red Hat® Instruct Model based on Granite 7B, an AI language model developed by Red Hat and IBM Research, based on the Granite-7b-base language model. My primary function is to be a chat assistant.",
     SupportedModelArchitectures.GRANITE: "I am a Red Hat® Instruct Model, an AI language model developed by Red Hat and IBM Research based on the granite-3.0-8b-base model. My primary role is to serve as a chat assistant.",
+    SupportedModelArchitectures.GRANITE3_128K: "I am a Red Hat® Instruct Model, an AI language model developed by Red Hat and IBM Research based on the granite-3.1-8b-instruct model. My primary role is to serve as a chat assistant.",
 }

--- a/src/instructlab/utils.py
+++ b/src/instructlab/utils.py
@@ -948,6 +948,10 @@ def get_model_arch(model_path: pathlib.Path) -> str:
         try:
             model_cfg = get_config_file_from_model(model_path, "config.json")
             model_arch = model_cfg["model_type"]
+            max_position_embeddings = model_cfg["max_position_embeddings"]
+            if model_arch == "granite" and max_position_embeddings >= 131072:
+                model_arch = "granite-3.1"
+                return model_arch
         except Exception as e:
             logger.debug(
                 f"Unable to get model architecture from config for model: {model_path}: {e}. Falling back to default value"

--- a/tests/common.py
+++ b/tests/common.py
@@ -35,8 +35,6 @@ def setup_gpus_config(section_path="serve", gpus=None, tps=None, vllm_args=lambd
 @mock.patch(
     "instructlab.model.backends.backends.check_model_path_exists", return_value=None
 )
-@mock.patch("instructlab.model.backends.vllm.check_api_base", return_value=False)
-# ^ mimic server *not* running already
 @mock.patch(
     "instructlab.model.backends.backends.determine_backend",
     return_value=("vllm", "testing"),

--- a/tests/common.py
+++ b/tests/common.py
@@ -41,7 +41,6 @@ def setup_gpus_config(section_path="serve", gpus=None, tps=None, vllm_args=lambd
     "instructlab.model.backends.backends.determine_backend",
     return_value=("vllm", "testing"),
 )
-@mock.patch("time.sleep", side_effect=Exception("Intended Abort"))
 @mock.patch("subprocess.Popen")
 def vllm_setup_test(runner, args, mock_popen, *_mock_args):
     mock_process = mock.MagicMock()

--- a/tests/test_lab_evaluate.py
+++ b/tests/test_lab_evaluate.py
@@ -276,12 +276,12 @@ def test_evaluate_mt_bench_branch(
     assert validate_model_mock.call_count == 3
     assert judge_answers_mock.call_count == 2
     assert gen_answers_mock.call_count == 2
-    assert launch_server_mock.call_count == 3
+    assert launch_server_mock.call_count == 4
     run_mt_bench_branch(cli_runner, 0.4567)
     assert validate_model_mock.call_count == 6
     assert judge_answers_mock.call_count == 4
     assert gen_answers_mock.call_count == 4
-    assert launch_server_mock.call_count == 6
+    assert launch_server_mock.call_count == 8
 
 
 @patch("instructlab.model.evaluate.validate_model")

--- a/tests/test_lab_serve.py
+++ b/tests/test_lab_serve.py
@@ -41,12 +41,14 @@ def assert_template(args, expect_chat, path_chat, chat_value):
         assert template == chat_value
 
 
-def vllm_setup_test_with_sleep_raise(*args, **kwargs):
+@mock.patch("instructlab.model.backends.vllm.check_api_base", return_value=False)
+# ^ mimic server *not* running already
+def vllm_setup_test_with_sleep_raise(runner, args, *_mock_args):
     # We assume that sleep is executed from inside the serve loop; at this
     # point, we are ready to exit from it; we trigger the exit with this side
     # effect, letting the serve function catch it and exit gracefully.
     with mock.patch("time.sleep", side_effect=Exception("Intended Abort")):
-        return common.vllm_setup_test(*args, **kwargs)
+        return common.vllm_setup_test(runner, args)
 
 
 def test_chat_auto(cli_runner: CliRunner):

--- a/tests/test_lab_serve.py
+++ b/tests/test_lab_serve.py
@@ -41,8 +41,16 @@ def assert_template(args, expect_chat, path_chat, chat_value):
         assert template == chat_value
 
 
+def vllm_setup_test_with_sleep_raise(*args, **kwargs):
+    # We assume that sleep is executed from inside the serve loop; at this
+    # point, we are ready to exit from it; we trigger the exit with this side
+    # effect, letting the serve function catch it and exit gracefully.
+    with mock.patch("time.sleep", side_effect=Exception("Intended Abort")):
+        return common.vllm_setup_test(*args, **kwargs)
+
+
 def test_chat_auto(cli_runner: CliRunner):
-    args = common.vllm_setup_test(
+    args = vllm_setup_test_with_sleep_raise(
         cli_runner,
         ["--config=DEFAULT", "model", "serve", "--model-path=foo"],
     )
@@ -53,7 +61,7 @@ def test_chat_auto(cli_runner: CliRunner):
 def test_chat_custom(cli_runner: CliRunner, tmp_path: pathlib.Path):
     file = tmp_path / "chat_template.jinja2"
     file.touch()
-    args = common.vllm_setup_test(
+    args = vllm_setup_test_with_sleep_raise(
         cli_runner,
         [
             "--config=DEFAULT",
@@ -68,7 +76,7 @@ def test_chat_custom(cli_runner: CliRunner, tmp_path: pathlib.Path):
 
 
 def test_chat_manual(cli_runner: CliRunner):
-    args = common.vllm_setup_test(
+    args = vllm_setup_test_with_sleep_raise(
         cli_runner,
         [
             "--config=DEFAULT",
@@ -83,7 +91,7 @@ def test_chat_manual(cli_runner: CliRunner):
 
 
 def test_gpus(cli_runner: CliRunner):
-    args = common.vllm_setup_test(
+    args = vllm_setup_test_with_sleep_raise(
         cli_runner,
         [
             "--config=DEFAULT",
@@ -98,7 +106,7 @@ def test_gpus(cli_runner: CliRunner):
 
 
 def test_gpus_default(cli_runner: CliRunner):
-    args = common.vllm_setup_test(
+    args = vllm_setup_test_with_sleep_raise(
         cli_runner,
         [
             "--config=DEFAULT",
@@ -111,7 +119,7 @@ def test_gpus_default(cli_runner: CliRunner):
 
 
 def test_ctx_tps_with_extra_params(cli_runner: CliRunner):
-    args = common.vllm_setup_test(
+    args = vllm_setup_test_with_sleep_raise(
         cli_runner,
         [
             "--config=DEFAULT",
@@ -131,7 +139,7 @@ def test_ctx_tps_with_extra_params(cli_runner: CliRunner):
 
 
 def test_ctx_tps_with_gpus(cli_runner: CliRunner):
-    args = common.vllm_setup_test(
+    args = vllm_setup_test_with_sleep_raise(
         cli_runner,
         [
             "--config=DEFAULT",
@@ -154,7 +162,7 @@ def test_ctx_tps_with_gpus(cli_runner: CliRunner):
 
 def test_gpus_config(cli_runner: CliRunner):
     fname = common.setup_gpus_config(gpus=8)
-    args = common.vllm_setup_test(
+    args = vllm_setup_test_with_sleep_raise(
         cli_runner,
         [
             f"--config={fname}",
@@ -168,7 +176,7 @@ def test_gpus_config(cli_runner: CliRunner):
 
 def test_gpus_with_gpus_config(cli_runner: CliRunner):
     fname = common.setup_gpus_config(gpus=8)
-    args = common.vllm_setup_test(
+    args = vllm_setup_test_with_sleep_raise(
         cli_runner,
         [
             f"--config={fname}",
@@ -184,7 +192,7 @@ def test_gpus_with_gpus_config(cli_runner: CliRunner):
 
 def test_ctx_tps_with_gpus_config(cli_runner: CliRunner):
     fname = common.setup_gpus_config(gpus=8)
-    args = common.vllm_setup_test(
+    args = vllm_setup_test_with_sleep_raise(
         cli_runner,
         [
             f"--config={fname}",
@@ -201,7 +209,7 @@ def test_ctx_tps_with_gpus_config(cli_runner: CliRunner):
 
 def test_gpus_with_ctx_tps_with_gpus_config(cli_runner: CliRunner):
     fname = common.setup_gpus_config(gpus=8)
-    args = common.vllm_setup_test(
+    args = vllm_setup_test_with_sleep_raise(
         cli_runner,
         [
             f"--config={fname}",
@@ -220,7 +228,7 @@ def test_gpus_with_ctx_tps_with_gpus_config(cli_runner: CliRunner):
 
 def test_vllm_args_config(cli_runner: CliRunner):
     fname = common.setup_gpus_config(tps=8)
-    args = common.vllm_setup_test(
+    args = vllm_setup_test_with_sleep_raise(
         cli_runner,
         [
             f"--config={fname}",
@@ -234,7 +242,7 @@ def test_vllm_args_config(cli_runner: CliRunner):
 
 def test_vllm_args_config_with_gpus_config(cli_runner: CliRunner):
     fname = common.setup_gpus_config(gpus=4, tps=8)
-    args = common.vllm_setup_test(
+    args = vllm_setup_test_with_sleep_raise(
         cli_runner,
         [
             f"--config={fname}",
@@ -248,7 +256,7 @@ def test_vllm_args_config_with_gpus_config(cli_runner: CliRunner):
 
 def test_vllm_args_config_with_gpus(cli_runner: CliRunner):
     fname = common.setup_gpus_config(tps=8)
-    args = common.vllm_setup_test(
+    args = vllm_setup_test_with_sleep_raise(
         cli_runner,
         [
             f"--config={fname}",
@@ -264,7 +272,7 @@ def test_vllm_args_config_with_gpus(cli_runner: CliRunner):
 
 def test_vllm_args_config_with_ctx_tps(cli_runner: CliRunner):
     fname = common.setup_gpus_config(tps=8)
-    args = common.vllm_setup_test(
+    args = vllm_setup_test_with_sleep_raise(
         cli_runner,
         [
             f"--config={fname}",
@@ -281,7 +289,7 @@ def test_vllm_args_config_with_ctx_tps(cli_runner: CliRunner):
 
 def test_vllm_args_null(cli_runner: CliRunner):
     fname = common.setup_gpus_config(vllm_args=lambda: None)
-    args = common.vllm_setup_test(
+    args = vllm_setup_test_with_sleep_raise(
         cli_runner,
         [
             f"--config={fname}",
@@ -338,7 +346,7 @@ def test_warn_for_unsupported_backend_param(param, expected_call_count):
 
 
 def test_serve_host(cli_runner: CliRunner):
-    args = common.vllm_setup_test(
+    args = vllm_setup_test_with_sleep_raise(
         cli_runner,
         [
             "--config=DEFAULT",
@@ -354,7 +362,7 @@ def test_serve_host(cli_runner: CliRunner):
 
 
 def test_serve_port(cli_runner: CliRunner):
-    args = common.vllm_setup_test(
+    args = vllm_setup_test_with_sleep_raise(
         cli_runner,
         [
             "--config=DEFAULT",
@@ -370,7 +378,7 @@ def test_serve_port(cli_runner: CliRunner):
 
 
 def test_serve_host_port(cli_runner: CliRunner):
-    args = common.vllm_setup_test(
+    args = vllm_setup_test_with_sleep_raise(
         cli_runner,
         [
             "--config=DEFAULT",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -200,11 +200,44 @@ def test_get_sysprompt():
         == "I am a Red Hat® Instruct Model, an AI language model developed by Red Hat and IBM Research based on the granite-3.0-8b-base model. My primary role is to serve as a chat assistant."
     )
 
+    arch = "granite-3.1"
+    assert (
+        utils.get_sysprompt(arch)
+        == "I am a Red Hat® Instruct Model, an AI language model developed by Red Hat and IBM Research based on the granite-3.1-8b-instruct model. My primary role is to serve as a chat assistant."
+    )
+
     arch = "random"
     assert (
         utils.get_sysprompt(arch)
         == "I am an advanced AI language model designed to assist you with a wide range of tasks and provide helpful, clear, and accurate responses. My primary role is to serve as a chat assistant, engaging in natural, conversational dialogue, answering questions, generating ideas, and offering support across various topics."
     )
+
+
+def test_get_model_arch_granite():
+    mock_path = pathlib.Path("/path/to/mock/granite/model")
+    mock_config = {
+        "model_type": "granite",
+        "max_position_embeddings": 32768,  # Less than 131072
+    }
+
+    with (
+        patch("instructlab.utils.is_model_safetensors", return_value=True),
+        patch("instructlab.utils.get_config_file_from_model", return_value=mock_config),
+    ):
+        result = utils.get_model_arch(mock_path)
+        assert result == "granite"
+
+
+def test_get_model_arch_granite_3_1():
+    mock_path = pathlib.Path("/path/to/mock/granite-3.1/model")
+    mock_config = {"model_type": "granite", "max_position_embeddings": 131072}
+
+    with (
+        patch("instructlab.utils.is_model_safetensors", return_value=True),
+        patch("instructlab.utils.get_config_file_from_model", return_value=mock_config),
+    ):
+        result = utils.get_model_arch(mock_path)
+        assert result == "granite-3.1"
 
 
 def test_get_model_template_from_tokenizer(tmp_path: pathlib.Path):


### PR DESCRIPTION
- Added RAG tests for taxonomy and model training flows
- Anticipated generation tests to use the output for taxonomy tests
- Using a different question for chats coming from taxonomy documents (`phoenix.md`)
- Added `retriever-top-k` option because when we put 20 documents in the message history, the less relevant (bottom of retrieval output) are the last in the history, so they seem instead more important. I verified that w/o this setting the output of the Phoenix-relayted question was not reliable.
- Updated `test_taxonomy` with updated paths and file names
- Added copy of `raw_documents` to the required folder (in alternative we can also change the command to ` ilab rag convert --input-dir "$SCRIPTDIR"/test-data/raw_documents` and avoid copying the same)
- Initialized feature gating env variables to prevent errors due to `-u` option
